### PR TITLE
Add delete all spaces option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ By default the following filters are defined (listed in the order of processing)
 - :strip (enabled by default) - removes whitespaces from the beginning and the end of string
 - :nullify (enabled by default) - replaces empty strings with nil
 - :squish (disabled by default) - replaces extra whitespaces (including tabs) with one space
+- :delete (disabled by default) - delete all whitespaces (including tabs)
 
 ### Custom Filters
 

--- a/lib/auto_strip_attributes.rb
+++ b/lib/auto_strip_attributes.rb
@@ -54,6 +54,9 @@ class AutoStripAttributes::Config
       set_filter :squish => false do |value|
         value.respond_to?(:gsub) ? value.gsub(/\s+/, ' ') : value
       end
+      set_filter :delete => false do |value|
+        value.respond_to?(:delete) ? value.delete(" \t") : value
+      end
     end
 
     instance_eval &block if block_given?

--- a/test/auto_strip_attributes_test.rb
+++ b/test/auto_strip_attributes_test.rb
@@ -133,6 +133,21 @@ describe AutoStripAttributes do
     end
   end
 
+  describe "Attribute with delete option" do
+    class MockRecordWithDelete < MockRecordParent
+      #column :foo, :string
+      attr_accessor :foo
+      auto_strip_attributes :foo, :delete => true
+    end
+
+    it "should delete all spaces and tabs" do
+      @record = MockRecordWithDelete.new
+      @record.foo = " a \t  bbb"
+      @record.valid?
+      @record.foo.must_equal "abbb"
+    end
+  end
+
   describe "Multible attributes with multiple options" do
     class MockRecordWithMultipleAttributes < MockRecordParent #< ActiveRecord::Base
       #column :foo, :string
@@ -184,7 +199,7 @@ describe AutoStripAttributes do
     it "should have default filters set in right order" do
       AutoStripAttributes::Config.setup :clear => true
       filters_order = AutoStripAttributes::Config.filters_order
-      filters_order.must_equal [:strip, :nullify, :squish]
+      filters_order.must_equal [:strip, :nullify, :squish, :delete]
     end
 
     it "should reset filters to defaults when :clear is true" do
@@ -195,7 +210,7 @@ describe AutoStripAttributes do
       end
       AutoStripAttributes::Config.setup :clear => true
       filters_order = AutoStripAttributes::Config.filters_order
-      filters_order.must_equal [:strip, :nullify, :squish]
+      filters_order.must_equal [:strip, :nullify, :squish, :delete]
     end
 
     it "should remove all filters when :clear is true and :defaults is false" do
@@ -228,7 +243,7 @@ describe AutoStripAttributes do
       filters_order = AutoStripAttributes::Config.filters_order
       filters_enabled = AutoStripAttributes::Config.filters_enabled
 
-      filters_order.must_equal [:strip, :nullify, :squish, :test]
+      filters_order.must_equal [:strip, :nullify, :squish, :delete, :test]
       assert Proc === filters_block[:test]
       filters_enabled[:test].must_equal true
 


### PR DESCRIPTION
Use case example : user providing large numbers like "225 500" (to_i = 225).

 I want full entered amount, aka 225500.
