### PR TITLE
Deal with ActiveRecord type cast

### DIFF
--- a/lib/auto_strip_attributes.rb
+++ b/lib/auto_strip_attributes.rb
@@ -9,7 +9,6 @@ module AutoStripAttributes
 
     attributes.each do |attribute|
       before_validation do |record|
-        #debugger
         value = record[attribute]
         AutoStripAttributes::Config.filters_order.each do |filter_name|
           next unless options[filter_name]

--- a/lib/auto_strip_attributes.rb
+++ b/lib/auto_strip_attributes.rb
@@ -9,7 +9,12 @@ module AutoStripAttributes
 
     attributes.each do |attribute|
       before_validation do |record|
-        value = record[attribute]
+        value = if record.is_a?(ActiveRecord::Base)
+          record.read_attribute_before_type_cast(attribute.to_s)
+        else
+          record.send(attribute)
+        end
+
         AutoStripAttributes::Config.filters_order.each do |filter_name|
           next unless options[filter_name]
           value = AutoStripAttributes::Config.filters[filter_name].call(value)

--- a/lib/auto_strip_attributes.rb
+++ b/lib/auto_strip_attributes.rb
@@ -12,7 +12,7 @@ module AutoStripAttributes
         value = record[attribute]
         AutoStripAttributes::Config.filters_order.each do |filter_name|
           next unless options[filter_name]
-          value = AutoStripAttributes::Config.filters[filter_name].call value
+          value = AutoStripAttributes::Config.filters[filter_name].call(value)
           record[attribute] = value
         end
       end


### PR DESCRIPTION
Use attributes values before type case for ActiveRecord objects

Otherwises ex. "10 200" still get typecasted to "10" before validations occurs.
