### PR TITLE
Add support to convert nbsp to spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ end
 
 By default the following filters are defined (listed in the order of processing):
 
+- :convert_non_breaking_spaces (disabled by default) - converts non-breaking spaces to normal spaces (Unicode U+00A0)
 - :strip (enabled by default) - removes whitespaces from the beginning and the end of string
 - :nullify (enabled by default) - replaces empty strings with nil
 - :squish (disabled by default) - replaces extra whitespaces (including tabs) with one space

--- a/lib/auto_strip_attributes.rb
+++ b/lib/auto_strip_attributes.rb
@@ -42,6 +42,9 @@ class AutoStripAttributes::Config
     @filters_order ||= []
 
     if options[:defaults]
+      set_filter :convert_non_breaking_spaces => false do |value|
+        value.respond_to?(:gsub) ? value.gsub("\u00A0", " ") : value
+      end
       set_filter :strip => true do |value|
         value.respond_to?(:strip) ? value.strip : value
       end


### PR DESCRIPTION
With this change one can easily convert non breaking spaces before running other filters. disabled by default.
