### PR TITLE
Removed ActiveRecord dependency from gemspec

### DIFF
--- a/auto_strip_attributes.gemspec
+++ b/auto_strip_attributes.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.add_runtime_dependency "activemodel", ">= 3.0"
+
   s.add_development_dependency "mocha", "~> 0.14"
   s.add_development_dependency 'rake'
 end


### PR DESCRIPTION
As this gem can be used with ActiveModel, ActiveRecord should not be a
required dependency of the gem.
