### PR TITLE
Fix warning

### DIFF
--- a/lib/auto_strip_attributes.rb
+++ b/lib/auto_strip_attributes.rb
@@ -62,7 +62,7 @@ class AutoStripAttributes::Config
       end
     end
 
-    instance_eval &block if block_given?
+    instance_eval(&block) if block_given?
   end
 
   def self.set_filter(filter,&block)
@@ -83,4 +83,3 @@ end
 ActiveRecord::Base.send(:extend, AutoStripAttributes) if defined? ActiveRecord
 AutoStripAttributes::Config.setup
 #ActiveModel::Validations::HelperMethods.send(:include, AutoStripAttributes) if defined? ActiveRecord
-


### PR DESCRIPTION
Using Ruby 2.3.0 and Rails 5.0.0 with this gem, the beginning of my rspec tests now show a warning message:

    /Users/pas256/..../auto_strip_attributes-2.0.6/lib/auto_strip_attributes.rb:65: warning: `&' interpreted as argument prefix

It is caused by this line:

    instance_eval &block if block_given?

I have put parenthesis around `&block` which removes the warning.

Can you please do a new release after merging this too? Thank you!