### PR TITLE
Added test matchers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ pkg/*
 .project
 .idea
 .redcar
+.ruby-version
 
 help

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It works by adding a before_validation hook to the record. No other methods are 
 
 Gem has option to set empty strings to nil or to remove extra spaces inside the string.
 
-[<img src="https://secure.travis-ci.org/holli/auto_strip_attributes.png" />](http://travis-ci.org/holli/auto_strip_attributes) 
+[<img src="https://secure.travis-ci.org/holli/auto_strip_attributes.png" />](http://travis-ci.org/holli/auto_strip_attributes)
 [![Gem](https://img.shields.io/gem/dt/auto_strip_attributes.svg?maxAge=2592000)](https://rubygems.org/gems/auto_strip_attributes/)
 [![Gem](https://img.shields.io/gem/v/auto_strip_attributes.svg?maxAge=2592000)](https://rubygems.org/gems/auto_strip_attributes/)
 
@@ -90,6 +90,57 @@ AutoStripAttributes::Config.setup accepts following options
 - :clear => true, to clear all filters
 - :defaults => true, to set three default filters mentioned above
 
+# Testing
+
+## Rspec
+
+### setup
+_spec_helper.rb
+
+```ruby
+require 'auto_strip_attributes/matchers'
+
+RSpec.configure do |config|
+  config.include AutoStripAttributes::Matchers, type: :model
+end
+```
+
+### Usage
+
+```ruby
+
+let(:user) { User.new }
+
+it { expect(user).to auto_strip(:name) }
+it { expect(user).to auto_strip(:name, :last_name) }
+```
+
+_examples:_
+
+will override the default examples and only try with the provided
+```ruby
+it { expect(user).to auto_strip(:name, :last_name).examples([['  hello  ', 'hello'], ['', '']]) }
+```
+
+_example:_
+Will override all examples and only execute the provided
+```ruby
+it { expect(user).to auto_strip(:name, :last_name).example('  hello  ', 'hello') }
+```
+
+_squish:_
+
+Will add an squish example.
+```ruby
+# if should squish default: true
+# 's   q' => 's q'
+it { expect(user).to auto_strip(:name, :last_name).squish }
+
+# 's   q' => 's   q'
+it { expect(user).to auto_strip(:name, :last_name).squish(false) }
+```
+
+
 
 # Versions
 
@@ -98,7 +149,7 @@ AutoStripAttributes::Config.setup accepts following options
 
 # Requirements
 
-Gem has been tested with newest Ruby & Rails combination and it probably works also with older versions. See test matrix at https://github.com/holli/auto_strip_attributes/blob/master/.travis.yml 
+Gem has been tested with newest Ruby & Rails combination and it probably works also with older versions. See test matrix at https://github.com/holli/auto_strip_attributes/blob/master/.travis.yml
 
 [<img src="https://secure.travis-ci.org/holli/auto_strip_attributes.png" />](http://travis-ci.org/holli/auto_strip_attributes)
 
@@ -130,4 +181,3 @@ different approaches. See discussion in previous chapter.
 # Licence
 
 Released under the MIT license (http://www.opensource.org/licenses/mit-license.php)
-

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ AutoStripAttributes::Config.setup accepts following options
 ## Rspec
 
 ### setup
-_spec_helper.rb
+_spec_helper.rb_
 
 ```ruby
 require 'auto_strip_attributes/matchers'
@@ -108,35 +108,39 @@ end
 ### Usage
 
 ```ruby
-
 let(:user) { User.new }
 
 it { expect(user).to auto_strip(:name) }
 it { expect(user).to auto_strip(:name, :last_name) }
 ```
 
-_examples:_
+**examples:**
 
 will override the default examples and only try with the provided
 ```ruby
 it { expect(user).to auto_strip(:name, :last_name).examples([['  hello  ', 'hello'], ['', '']]) }
 ```
 
-_example:_
+**example:**
+
 Will override all examples and only execute the provided
 ```ruby
 it { expect(user).to auto_strip(:name, :last_name).example('  hello  ', 'hello') }
 ```
-
-_squish:_
+**squish:**
 
 Will add an squish example.
-```ruby
-# if should squish default: true
-# 's   q' => 's q'
-it { expect(user).to auto_strip(:name, :last_name).squish }
+if it should squish, default: true
+`'s   q' => 's q'`
 
-# 's   q' => 's   q'
+```ruby
+it { expect(user).to auto_strip(:name, :last_name).squish }
+```
+
+if it should not
+`'s   q' => 's   q'`
+
+```ruby
 it { expect(user).to auto_strip(:name, :last_name).squish(false) }
 ```
 

--- a/lib/auto_strip_attributes/matchers.rb
+++ b/lib/auto_strip_attributes/matchers.rb
@@ -1,0 +1,79 @@
+module AutoStripAttributes
+  module Matchers
+
+    def auto_strip(*attrs)
+      AutoStrip.new(attrs)
+    end
+
+    class AutoStrip
+
+      attr_reader :attrs, :model, :descriptions, :failure_messages
+      def initialize(attrs)
+        @attrs = attrs
+        @failure_messages = []
+        @descriptions = ["auto strips attributes `#{attrs.join(', ')}`"]
+      end
+
+      def matches?(model)
+        @model = model
+        _examples.all? do |ex|
+          execute_example(ex)
+        end
+      end
+
+      def failure_message
+        failure_messages.join(' ')
+      end
+
+      def description
+        descriptions.join(' ')
+      end
+
+      def squish(bool = true)
+        if bool
+          _examples.append(['squ  ish', 'squ ish'])
+        else
+          _examples.append(['squ  ish', 'squ  ish'])
+        end
+        self
+      end
+
+      def examples(ary)
+        descriptions << "with examples: `#{ary}`"
+        @examples = ary
+        self
+      end
+
+      def example(actual, expected)
+        descriptions << "with example: `#{actual}` to `#{expected}`"
+        @examples = [[actual, expected]]
+        self
+      end
+
+      private
+
+      def execute_example(example)
+        attrs.each do |attribute|
+          model.send("#{attribute}=", example[0])
+        end
+        model.valid?
+        out = attrs.all? do |attribute|
+                model.send(attribute) == example[1]
+              end
+        append_error(example) unless out
+        out
+      end
+
+      def append_error(example)
+        failure_messages << "change `#{example[0]}` to `#{example[1].nil? ? 'nil' : example[1]}`"
+      end
+
+      def _examples
+        @examples ||= [
+          [" aaa \t", 'aaa'],
+          ['', nil]
+        ]
+      end
+    end
+  end
+end

--- a/lib/auto_strip_attributes/matchers.rb
+++ b/lib/auto_strip_attributes/matchers.rb
@@ -10,8 +10,8 @@ module AutoStripAttributes
       attr_reader :attrs, :model, :descriptions, :failure_messages
       def initialize(attrs)
         @attrs = attrs
-        @failure_messages = []
-        @descriptions = ["auto strips attributes `#{attrs.join(', ')}`"]
+        @failure_messages = ["should auto_strip"]
+        @descriptions = ["auto strip attributes `#{attrs.join(', ')}`"]
       end
 
       def matches?(model)
@@ -57,15 +57,18 @@ module AutoStripAttributes
           model.send("#{attribute}=", example[0])
         end
         model.valid?
-        out = attrs.all? do |attribute|
-                model.send(attribute) == example[1]
-              end
-        append_error(example) unless out
-        out
+        attrs.all? do |attribute|
+          if model.send(attribute) == example[1]
+            true
+          else
+            append_error(attribute, example)
+            false
+          end
+        end
       end
 
-      def append_error(example)
-        failure_messages << "change `#{example[0]}` to `#{example[1].nil? ? 'nil' : example[1]}`"
+      def append_error(attribute, example)
+        failure_messages << "`#{attribute}`"
       end
 
       def _examples

--- a/test/auto_strip_attributes_test.rb
+++ b/test/auto_strip_attributes_test.rb
@@ -7,6 +7,7 @@ require 'minitest/spec'
 require "active_record"
 require "auto_strip_attributes"
 require 'mocha/setup'
+require File.expand_path('mock_record_parent', __dir__)
 
 # if you need debug, add relevant line to auto_strip_attributes.gemspec
 # s.add_development_dependency 'ruby-debug'
@@ -15,22 +16,7 @@ require 'mocha/setup'
 # require 'ruby-debug'
 
 
-class MockRecordParent
-  include ActiveModel::Validations
-  include ActiveModel::Validations::Callbacks
-  extend AutoStripAttributes
 
-  # Overriding @record[key]=val , that's only found in activerecord, not in ActiveModel
-  def []=(key, val)
-    # send("#{key}=", val)  # We dont want to call setter again
-    instance_variable_set(:"@#{key}", val)
-  end
-
-  def [](key)
-    instance_variable_get(:"@#{key}")
-  end
-
-end
 
 describe AutoStripAttributes do
 
@@ -342,6 +328,4 @@ describe AutoStripAttributes do
       @record.bar_downcase.must_equal ""
     end
   end
-
-
 end

--- a/test/auto_strip_matcher_test.rb
+++ b/test/auto_strip_matcher_test.rb
@@ -1,0 +1,14 @@
+require 'minitest/autorun'
+require 'minitest/spec'
+require "active_record"
+require "auto_strip_attributes"
+require 'mocha/setup'
+require 'auto_strip_attributes/matchers'
+
+# MiniTest::Unit::TestCase.register_matcher :auto_strip, :auto_strip
+
+describe 'matchers' do
+  it do
+
+  end
+end

--- a/test/mock_record_parent.rb
+++ b/test/mock_record_parent.rb
@@ -1,0 +1,16 @@
+class MockRecordParent
+  include ActiveModel::Validations
+  include ActiveModel::Validations::Callbacks
+  extend AutoStripAttributes
+
+  # Overriding @record[key]=val , that's only found in activerecord, not in ActiveModel
+  def []=(key, val)
+    # send("#{key}=", val)  # We dont want to call setter again
+    instance_variable_set(:"@#{key}", val)
+  end
+
+  def [](key)
+    instance_variable_get(:"@#{key}")
+  end
+
+end


### PR DESCRIPTION
If added matchers for testing.
I could not test in this project because I'm not used to minitest and I did not find  how to include the matchers.

I could test it with rspec or if somebody knows the way to test it in minitest ....

Thanks, I wait for your feedback

---
## Rspec
### setup

_spec_helper.rb_

``` ruby
require 'auto_strip_attributes/matchers'

RSpec.configure do |config|
  config.include AutoStripAttributes::Matchers, type: :model
end
```
### Usage

``` ruby
let(:user) { User.new }

it { expect(user).to auto_strip(:name) }
it { expect(user).to auto_strip(:name, :last_name) }
```

**examples:**

will override the default examples and only try with the provided

``` ruby
it { expect(user).to auto_strip(:name, :last_name).examples([['  hello  ', 'hello'], ['', '']]) }
```

**example:**

Will override all examples and only execute the provided

``` ruby
it { expect(user).to auto_strip(:name, :last_name).example('  hello  ', 'hello') }
```

**squish:**

Will add an squish example.
if it should squish, default: true
`'s   q' => 's q'`

``` ruby
it { expect(user).to auto_strip(:name, :last_name).squish }
```

if it should not
`'s   q' => 's   q'`

``` ruby
it { expect(user).to auto_strip(:name, :last_name).squish(false) }
```
