### PR TITLE
:squish should work with all Unicode whitespaces.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ class User < ActiveRecord::Base
   auto_strip_attributes :nick, :comment
 
   # Squeezes spaces inside the string: "James     Bond  " => "James Bond"
-  auto_strip_attributes :name, :squish => true
+  auto_strip_attributes :name, squish: true
 
   # Won't set to null even if string is blank. "   " => ""
-  auto_strip_attributes :email, :nullify => false
+  auto_strip_attributes :email, nullify: false
 
   # Use with attributes that are not mapped to a column
   auto_strip_attributes :password, virtual: true
@@ -41,12 +41,12 @@ end
 
 By default the following options are defined (listed in the order of processing):
 
-- :strip (enabled by default) - removes whitespaces from the beginning and the end of string
-- :nullify (enabled by default) - replaces empty strings with nil
-- :squish (disabled by default) - replaces extra whitespaces (including tabs) with one space
-- :delete_whitespaces (disabled by default) - delete all whitespaces (including tabs)
-- :convert_non_breaking_spaces (disabled by default) - converts non-breaking spaces to normal spaces (Unicode U+00A0)
-- :virtual (disabled by default) - By default `auto_strip_attributes` doesn't work with non-persistent attributes (e.g., attributes that are created with `attr_accessor`). This is to avoid calling their custom getter/setter methods. Use this option with non-persistent attributes.
+- `:strip` (enabled by default) - removes whitespaces from the beginning and the end of string. Works exactly same as `String#strip`, i.e., may not strip non-ASCII whitespaces.
+- `:nullify` (enabled by default) - replaces empty strings with nil.
+- `:squish` (disabled by default) - replaces all consecutive Unicode whitespace characters (including tabs and new lines) with single space (U+0020) and then strips the string.
+- `:delete_whitespaces` (disabled by default) - deletes all spaces (U+0020) and tabs (U+0009).
+- `:convert_non_breaking_spaces` (disabled by default) - converts non-breaking spaces (U+00A0) to normal spaces (U+0020).
+- `:virtual` (disabled by default) - By default `auto_strip_attributes` doesn't work with non-persistent attributes (e.g., attributes that are created with `attr_accessor`). This is to avoid calling their custom getter/setter methods. Use this option with non-persistent attributes.
 
 ### Custom Filters
 

--- a/lib/auto_strip_attributes.rb
+++ b/lib/auto_strip_attributes.rb
@@ -67,7 +67,8 @@ class AutoStripAttributes::Config
         (value.respond_to?(:'blank?') and value.respond_to?(:'empty?') and value.blank?) ? nil : value
       end
       set_filter :squish => false do |value|
-        value.respond_to?(:gsub) ? value.gsub(/\s+/, ' ') : value
+        value = value.respond_to?(:gsub) ? value.gsub(/[[:space:]]+/, ' ') : value
+        value.respond_to?(:strip) ? value.strip : value
       end
       set_filter :delete_whitespaces => false do |value|
         value.respond_to?(:delete) ? value.delete(" \t") : value

--- a/test/auto_strip_attributes_test.rb
+++ b/test/auto_strip_attributes_test.rb
@@ -154,12 +154,13 @@ describe AutoStripAttributes do
     class MockRecordWithSqueeze < MockRecordParent #< ActiveRecord::Base
       #column :foo, :st
       attr_accessor :foo
-      auto_strip_attributes :foo, :squish => true
+      # test that `:squish => true` implies `:strip => true`
+      auto_strip_attributes :foo, :squish => true, :strip => false
     end
 
     it "should squish string also form inside" do
       @record = MockRecordWithSqueeze.new
-      @record.foo = "  aaa\t\n     bbb"
+      @record.foo = "  aaa \u0009 \u000A \u000B \u000C \u000D \u0020 \u0085 \u00A0 \u1680 \u2000 \u2001 \u2002 \u2003 \u2004 \u2005 \u2006 \u2007 \u2008 \u2009 \u200A \u2028 \u2029 \u202F \u205F \u3000 bbb  \u00A0   "
       @record.valid?
       @record.foo.must_equal "aaa bbb"
     end


### PR DESCRIPTION
This PR replaces `/\s+/` with `/[[:space:]]+/` for `squish` option, which means that `squish` will now squish [all Unicode whitespaces](https://en.wikipedia.org/wiki/Whitespace_character#Unicode).

`squish` should also imply `strip` (code examples in both README and in tests confirm this), so `squish` option will now also strip the value. This also makes it behave [exactly like String#squish](https://github.com/rails/rails/blob/v5.1.4/activesupport/lib/active_support/core_ext/string/filters.rb#L19).

Also added ASCII/Unicode related caveats for each option in README.