### PR TITLE
Add `truncate` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ class User < ActiveRecord::Base
 
   # Use with attributes that are not mapped to a column
   auto_strip_attributes :password, virtual: true
+
+  # Truncate the attribute
+  auto_strip_attributes :description, truncate: 255
 end
 ```
 
@@ -46,7 +49,8 @@ By default the following options are defined (listed in the order of processing)
 - `:squish` (disabled by default) - replaces all consecutive Unicode whitespace characters (including tabs and new lines) with single space (U+0020). Works exactly same as Rails `String#squish`
 - `:delete_whitespaces` (disabled by default) - deletes all spaces (U+0020) and tabs (U+0009).
 - `:convert_non_breaking_spaces` (disabled by default) - converts non-breaking spaces (U+00A0) to normal spaces (U+0020).
-- `:virtual` (disabled by default) - By default `auto_strip_attributes` doesn't work with non-persistent attributes (e.g., attributes that are created with `attr_accessor`). This is to avoid calling their custom getter/setter methods. Use this option with non-persistent attributes.
+- `:truncate` (disabled by default) - truncate the string to given length. Truncation happens after whitespaces are removed.
+- `:virtual` (disabled by default) - by default `auto_strip_attributes` doesn't work with non-persistent attributes (e.g., attributes that are created with `attr_accessor`). This is to avoid calling their custom getter/setter methods. Use this option with non-persistent attributes.
 
 ### Custom Filters
 
@@ -65,13 +69,19 @@ AutoStripAttributes::Config.setup do
   set_filter :strip_html => false do |value|
     ActionController::Base.helpers.strip_tags value
   end
+
+  # Use `String#truncate` provided by ActiveSupport
+  set_filter better_truncate: false do |value, options|
+    value.truncate(options.delete(:length), options)
+  end
 end
 
 
 And in the model:
 
 class User < ActiveRecord::Base
-  auto_strip_attributes :extra_info, :strip_html => true
+  auto_strip_attributes :extra_info, strip_html: true
+  auto_strip_attributes :description, better_truncate: { length: 255, separator: " ", omission: "…" }
 end
 
 ```

--- a/lib/auto_strip_attributes.rb
+++ b/lib/auto_strip_attributes.rb
@@ -21,7 +21,7 @@ module AutoStripAttributes
         end
         AutoStripAttributes::Config.filters_order.each do |filter_name|
           next unless options[filter_name]
-          value = AutoStripAttributes::Config.filters[filter_name].call value
+          value = AutoStripAttributes::Config.filters[filter_name].call value, options[filter_name]
           if virtual
             record.public_send("#{attribute}=", value)
           else
@@ -72,6 +72,12 @@ class AutoStripAttributes::Config
       end
       set_filter :delete_whitespaces => false do |value|
         value.respond_to?(:delete) ? value.delete(" \t") : value
+      end
+      set_filter :truncate => false do |value, options|
+        unless options.is_a?(Integer) && options > 0
+          raise "Expected :truncate option to be a positive integer, found #{options.inspect} instead"
+        end
+        value.to_s[0, options]
       end
     end
 

--- a/test/auto_strip_attributes_test.rb
+++ b/test/auto_strip_attributes_test.rb
@@ -231,6 +231,35 @@ describe AutoStripAttributes do
     end
   end
 
+  describe "truncate option" do
+    class MockRecordForTruncate < MockRecordParent
+      attr_accessor :foo
+      auto_strip_attributes :foo, truncate: 5
+    end
+
+    class MockRecordForTruncateError < MockRecordParent
+      attr_accessor :foo
+      auto_strip_attributes :foo, truncate: true
+    end
+
+    it "should truncate the value" do
+      @record = MockRecordForTruncate.new
+      @record.foo = "  1234567890  "
+      @record.valid?
+      @record.foo.must_equal "12345"
+    end
+
+    it "should raise an error if truncate option is not an integer" do
+      error_message = "Expected :truncate option to be a positive integer, found true instead"
+
+      @record = MockRecordForTruncateError.new
+      @record.foo = "  1234567890  "
+      assert_raises(error_message) do
+        @record.valid?
+      end
+    end
+  end
+
   describe "Virtual attributes" do
     class MockVirtualAttribute < MockRecordParent
       undef :[]=
@@ -264,7 +293,7 @@ describe AutoStripAttributes do
     it "should have default filters set in right order" do
       AutoStripAttributes::Config.setup :clear => true
       filters_order = AutoStripAttributes::Config.filters_order
-      filters_order.must_equal [:convert_non_breaking_spaces, :strip, :nullify, :squish, :delete_whitespaces]
+      filters_order.must_equal [:convert_non_breaking_spaces, :strip, :nullify, :squish, :delete_whitespaces, :truncate]
     end
 
     it "should reset filters to defaults when :clear is true" do
@@ -275,7 +304,7 @@ describe AutoStripAttributes do
       end
       AutoStripAttributes::Config.setup :clear => true
       filters_order = AutoStripAttributes::Config.filters_order
-      filters_order.must_equal [:convert_non_breaking_spaces, :strip, :nullify, :squish, :delete_whitespaces]
+      filters_order.must_equal [:convert_non_breaking_spaces, :strip, :nullify, :squish, :delete_whitespaces, :truncate]
     end
 
     it "should remove all filters when :clear is true and :defaults is false" do
@@ -308,7 +337,7 @@ describe AutoStripAttributes do
       filters_order = AutoStripAttributes::Config.filters_order
       filters_enabled = AutoStripAttributes::Config.filters_enabled
 
-      filters_order.must_equal [:convert_non_breaking_spaces, :strip, :nullify, :squish, :delete_whitespaces, :test]
+      filters_order.must_equal [:convert_non_breaking_spaces, :strip, :nullify, :squish, :delete_whitespaces, :truncate, :test]
       assert Proc === filters_block[:test]
       filters_enabled[:test].must_equal true
 


### PR DESCRIPTION
We often need to truncate attributes to satisfy database column length constraints.
I think a simple `truncate` option would be a nice addition to auto_strip_attributes gem.