### PR TITLE
Support ActiveModel options for before_validation callback

### DIFF
--- a/lib/auto_strip_attributes.rb
+++ b/lib/auto_strip_attributes.rb
@@ -12,7 +12,7 @@ module AutoStripAttributes
     virtual = options.delete(:virtual)
 
     attributes.each do |attribute|
-      before_validation do |record|
+      before_validation(options) do |record|
         if virtual
           value = record.public_send(attribute)
         else

--- a/test/auto_strip_attributes_test.rb
+++ b/test/auto_strip_attributes_test.rb
@@ -49,6 +49,27 @@ describe AutoStripAttributes do
     assert Object.const_defined?(:AutoStripAttributes)
   end
 
+  describe "Basic attribute with default options and conditional evaluation" do
+    class MockRecordBasic < MockRecordParent
+      attr_accessor :boo
+      auto_strip_attributes :boo, if: ->(record) { record[:boo] == " bbb \t" }
+    end
+
+    it "should not strip when conditional is not met" do
+      @record = MockRecordBasic.new()
+      @record.boo = " aaa \t"
+      @record.valid?
+      @record.boo.must_equal " aaa \t"
+    end
+
+    it "should strip when conditional is met" do
+      @record = MockRecordBasic.new()
+      @record.boo = " bbb \t"
+      @record.valid?
+      @record.boo.must_equal "bbb"
+    end
+  end
+
   describe "Basic attribute with default options" do
     class MockRecordBasic < MockRecordParent
       attr_accessor :foo


### PR DESCRIPTION
Sometimes we need to allow for conditional evaluation in the `before_validation` callback. This adds support for those features and other options already allowed by ActiveModel.