### PR TITLE
Regenerate badges for README, use SVGs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ It works by adding a before_validation hook to the record. No other methods are 
 
 Gem has option to set empty strings to nil or to remove extra spaces inside the string.
 
-[<img src="https://secure.travis-ci.org/holli/auto_strip_attributes.png" />](http://travis-ci.org/holli/auto_strip_attributes)
-[![Gem](https://img.shields.io/gem/dt/auto_strip_attributes.svg?maxAge=2592000)](https://rubygems.org/gems/auto_strip_attributes/)
-[![Gem](https://img.shields.io/gem/v/auto_strip_attributes.svg?maxAge=2592000)](https://rubygems.org/gems/auto_strip_attributes/)
+[![Build Status](https://travis-ci.org/holli/auto_strip_attributes.svg?branch=master)](https://travis-ci.org/holli/auto_strip_attributes)
+[![Downloads](https://img.shields.io/gem/dt/auto_strip_attributes)](https://rubygems.org/gems/auto_strip_attributes/)
+[![Gem](https://img.shields.io/gem/v/auto_strip_attributes)](https://rubygems.org/gems/auto_strip_attributes/)
 
 ## Howto / examples
 
@@ -130,7 +130,7 @@ AutoStripAttributes::Config.setup accepts following options
 
 Gem has been tested with newest Ruby & Rails combination and it probably works also with older versions. See test matrix at https://github.com/holli/auto_strip_attributes/blob/master/.travis.yml
 
-[<img src="https://secure.travis-ci.org/holli/auto_strip_attributes.png" />](http://travis-ci.org/holli/auto_strip_attributes)
+[![Build Status](https://travis-ci.org/holli/auto_strip_attributes.svg?branch=master)](https://travis-ci.org/holli/auto_strip_attributes)
 
 # Support
 


### PR DESCRIPTION
Before:
![Screenshot 2020-03-12 at 11 12 12](https://user-images.githubusercontent.com/1301152/76511252-37d52480-6453-11ea-8034-17dc3f57e4ac.png)

After:
![Screenshot 2020-03-12 at 11 18 16](https://user-images.githubusercontent.com/1301152/76511265-3ad01500-6453-11ea-88b7-089eeab65009.png)

I regenerated the URLs  using the https://shields.io/ generator, that's why the URLs changed.