### PR TITLE
Add Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,9 +19,11 @@ jobs:
             rails-version: '6.0.0'
           - ruby-version: '2.6.10'
             rails-version: '6.1.0'
-          - ruby-version: '3.1.2'  # 3.1 (extended to 3.1.3) didn't work
+          - ruby-version: '3.2'
             rails-version: '7.0.0'
 
+    env:
+      RAILS_VERSION: ${{ matrix.rails-version }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby ${{ matrix.ruby-version }}
@@ -29,10 +31,6 @@ jobs:
         with:
           bundler-cache: true
           ruby-version: ${{ matrix.ruby-version }}
-        env:
-          RAILS_VERSION: ${{ matrix.rails-version }}
-      - name: Install dependencies
-        run: bundle install
       - name: Run tests
         run: bundle exec rake
 

--- a/auto_strip_attributes.gemspec
+++ b/auto_strip_attributes.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   #s.add_development_dependency "activerecord", ">= 3.0"
   s.add_development_dependency "minitest", ">= 3.0"
-  s.add_development_dependency "mocha", "~> 0.14"
+  s.add_development_dependency "mocha", "~> 2.0"
   s.add_development_dependency 'rake'
   # s.add_development_dependency 'pry'
 

--- a/test/auto_strip_attributes_test.rb
+++ b/test/auto_strip_attributes_test.rb
@@ -6,7 +6,7 @@ require 'minitest/autorun'
 require 'minitest/spec'
 require "active_record"
 require "auto_strip_attributes"
-require 'mocha/setup'
+require 'mocha/minitest'
 
 # if you need debug, add relevant line to auto_strip_attributes.gemspec
 # s.add_development_dependency 'pry'


### PR DESCRIPTION
I also did some minor neatening up of the GitHub Actions file, and upgraded the mocha gem.  

Runs green on my fork. 
